### PR TITLE
Feature/funding

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,8 @@ dependencies {
 
 	implementation 'org.apache.tika:tika-core:2.9.1'
 
+	implementation 'org.redisson:redisson-spring-boot-starter:3.25.2'
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/zerobase/funding/api/auth/jwt/TokenProvider.java
+++ b/src/main/java/com/zerobase/funding/api/auth/jwt/TokenProvider.java
@@ -16,11 +16,13 @@ import jakarta.annotation.PostConstruct;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.crypto.SecretKey;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Component;
@@ -56,9 +58,13 @@ public class TokenProvider {
         Date now = new Date();
         Date expiredDate = new Date(now.getTime() + expireTime);
 
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining());
+
         return Jwts.builder()
                 .subject(authentication.getName())
-                .claim(KEY_ROLE, authentication.getAuthorities())
+                .claim(KEY_ROLE, authorities)
                 .issuedAt(now)
                 .expiration(expiredDate)
                 .signWith(secretKey, Jwts.SIG.HS512)

--- a/src/main/java/com/zerobase/funding/api/auth/service/AuthenticationService.java
+++ b/src/main/java/com/zerobase/funding/api/auth/service/AuthenticationService.java
@@ -8,10 +8,13 @@ import com.zerobase.funding.domain.member.entity.Member;
 import com.zerobase.funding.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Service
 public class AuthenticationService {
+
     private final MemberRepository memberRepository;
 
     public Member getMemberOrThrow(String memberKey) {
@@ -23,5 +26,11 @@ public class AuthenticationService {
         if (!member.getMemberKey().equals(memberKey)) {
             throw new AuthException(NO_ACCESS);
         }
+    }
+
+    public void existsMemberOrThrow(String memberKey) {
+       if (!memberRepository.existsByMemberKey(memberKey)) {
+           throw new AuthException(MEMBER_NOT_FOUND);
+       }
     }
 }

--- a/src/main/java/com/zerobase/funding/api/common/constants/RedisKey.java
+++ b/src/main/java/com/zerobase/funding/api/common/constants/RedisKey.java
@@ -1,0 +1,5 @@
+package com.zerobase.funding.api.common.constants;
+
+public class RedisKey {
+    public static final String FUNDING_LOCK_PREFIX = "funding:create:rewardId:";
+}

--- a/src/main/java/com/zerobase/funding/api/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/funding/api/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     // funding
     FUNDING_NOT_FOUND(NOT_FOUND, "펀딩을 찾을 수 없습니다."),
     REWARD_NOT_MATCH(BAD_REQUEST, "해당 상품의 리워드가 아닙니다."),
+    ADDRESS_IS_REQUIRED(BAD_REQUEST, "배송할 주소가 필요합니다."),
     OUT_OF_STOCK(BAD_REQUEST, "재고가 부족합니다."),
 
     // reward

--- a/src/main/java/com/zerobase/funding/api/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/funding/api/exception/ErrorCode.java
@@ -26,6 +26,14 @@ public enum ErrorCode {
 
     // funding
     FUNDING_NOT_FOUND(NOT_FOUND, "펀딩을 찾을 수 없습니다."),
+    REWARD_NOT_MATCH(BAD_REQUEST, "해당 상품의 리워드가 아닙니다."),
+    OUT_OF_STOCK(BAD_REQUEST, "재고가 부족합니다."),
+
+    // reward
+    REWARD_NOT_FOUND(NOT_FOUND, "리워드를 찾을 수 없습니다."),
+
+    // payment history
+    INVALID_PAYMENT(BAD_REQUEST, "결제 정보가 일치하지 않습니다."),
 
     // global
     NO_ACCESS(FORBIDDEN, "접근 권한이 없습니다."),

--- a/src/main/java/com/zerobase/funding/api/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/funding/api/exception/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
     REWARD_NOT_MATCH(BAD_REQUEST, "해당 상품의 리워드가 아닙니다."),
     ADDRESS_IS_REQUIRED(BAD_REQUEST, "배송할 주소가 필요합니다."),
     OUT_OF_STOCK(BAD_REQUEST, "재고가 부족합니다."),
+    ALREADY_FUNDED_REWARD(BAD_REQUEST, "이미 해당 리워드에 펀딩하였습니다."),
 
     // reward
     REWARD_NOT_FOUND(NOT_FOUND, "리워드를 찾을 수 없습니다."),
@@ -37,6 +38,7 @@ public enum ErrorCode {
     INVALID_PAYMENT(BAD_REQUEST, "결제 정보가 일치하지 않습니다."),
 
     // global
+    RESOURCE_LOCKED(LOCKED, "자원이 잠겨있어 접근할 수 없습니다."),
     NO_ACCESS(FORBIDDEN, "접근 권한이 없습니다."),
     RESOURCE_NOT_FOUND(NOT_FOUND, "요청한 자원을 찾을 수 없습니다."),
     INVALID_REQUEST(BAD_REQUEST, "올바르지 않은 요청입니다."),

--- a/src/main/java/com/zerobase/funding/api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/zerobase/funding/api/exception/GlobalExceptionHandler.java
@@ -38,11 +38,11 @@ public class GlobalExceptionHandler {
         return toResponse(RESOURCE_NOT_FOUND, RESOURCE_NOT_FOUND.getMessage());
     }
 
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<?> handleException(Exception e) {
-        log.error("Exception is occurred. ", e);
-        return toResponse(INTERNAL_ERROR, e.getMessage());
-    }
+//    @ExceptionHandler(Exception.class)
+//    public ResponseEntity<?> handleException(Exception e) {
+//        log.error("Exception is occurred. ", e);
+//        return toResponse(INTERNAL_ERROR, e.getMessage());
+//    }
 
     private static ResponseEntity<ErrorResponse> toResponse(ErrorCode errorCode, String message) {
         return ResponseEntity.status(errorCode.getHttpStatus())

--- a/src/main/java/com/zerobase/funding/api/funding/controller/FundingController.java
+++ b/src/main/java/com/zerobase/funding/api/funding/controller/FundingController.java
@@ -1,0 +1,37 @@
+package com.zerobase.funding.api.funding.controller;
+
+import com.zerobase.funding.api.auth.annotaion.RoleUser;
+import com.zerobase.funding.api.funding.dto.CreateFunding;
+import com.zerobase.funding.api.funding.service.FundingService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/funding")
+@RequiredArgsConstructor
+@RestController
+public class FundingController {
+
+    private final FundingService fundingService;
+
+    /**
+     * 펀딩하기
+     * @param request 펀딩 요청 정보
+     * @param userDetails 인증 유저
+     * @return 펀딩 정보
+     */
+    @RoleUser
+    @PostMapping
+    public ResponseEntity<CreateFunding.Response> createFunding(
+            @RequestBody @Valid CreateFunding.Request request,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        return ResponseEntity.ok(
+                fundingService.createFunding(request, userDetails.getUsername()));
+    }
+}

--- a/src/main/java/com/zerobase/funding/api/funding/dto/CreateFunding.java
+++ b/src/main/java/com/zerobase/funding/api/funding/dto/CreateFunding.java
@@ -1,0 +1,46 @@
+package com.zerobase.funding.api.funding.dto;
+
+import com.zerobase.funding.api.member.dto.model.AddressDto;
+import com.zerobase.funding.domain.funding.entity.Funding;
+import com.zerobase.funding.domain.funding.entity.Status;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+public record CreateFunding() {
+
+    public record Request(
+            @NotNull
+            Long fundingProductId,
+
+            @NotNull
+            Long rewardId,
+
+            @Nullable
+            AddressDto address
+    ) {
+
+        public Funding toEntity(Integer fundingPrice) {
+            return Funding.builder()
+                    .status(Status.IN_PROGRESS)
+                    .fundingPrice(fundingPrice)
+                    .build();
+        }
+    }
+
+    @Builder
+    public record Response(
+            String rewardTitle,
+            Integer price,
+            Long fundingId
+    ) {
+
+        public static Response from(String rewardTitle, Integer price, Long fundingId) {
+            return Response.builder()
+                    .rewardTitle(rewardTitle)
+                    .price(price)
+                    .fundingId(fundingId)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/zerobase/funding/api/funding/service/FundingService.java
+++ b/src/main/java/com/zerobase/funding/api/funding/service/FundingService.java
@@ -1,10 +1,24 @@
 package com.zerobase.funding.api.funding.service;
 
+import static com.zerobase.funding.api.exception.ErrorCode.FUNDING_NOT_FOUND;
+import static com.zerobase.funding.api.exception.ErrorCode.OUT_OF_STOCK;
+import static com.zerobase.funding.api.exception.ErrorCode.REWARD_NOT_MATCH;
+import static com.zerobase.funding.domain.delivery.entity.Status.WAITING;
+import static com.zerobase.funding.domain.funding.entity.Status.IN_PROGRESS;
+
+import com.zerobase.funding.api.auth.service.AuthenticationService;
+import com.zerobase.funding.api.funding.dto.CreateFunding;
+import com.zerobase.funding.api.funding.dto.CreateFunding.Request;
+import com.zerobase.funding.api.funding.exception.FundingException;
+import com.zerobase.funding.api.member.dto.model.AddressDto;
+import com.zerobase.funding.api.reward.service.RewardService;
+import com.zerobase.funding.domain.delivery.entity.Delivery;
 import com.zerobase.funding.domain.funding.entity.Funding;
-import com.zerobase.funding.domain.funding.entity.Status;
 import com.zerobase.funding.domain.funding.repository.FundingRepository;
+import com.zerobase.funding.domain.member.entity.Member;
 import com.zerobase.funding.domain.reward.entity.Reward;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,8 +29,49 @@ import org.springframework.transaction.annotation.Transactional;
 public class FundingService {
 
     private final FundingRepository fundingRepository;
+    private final AuthenticationService authenticationService;
+    private final RewardService rewardService;
 
-    public List<Funding> findByRewards(List<Reward> rewards) {
-        return fundingRepository.findByRewardInAndStatus(rewards, Status.IN_PROGRESS);
+    public List<Funding> getFundingByRewards(List<Reward> rewards) {
+        return fundingRepository.findByRewardInAndStatus(rewards, IN_PROGRESS);
+    }
+
+    public Funding getFundingById(Long id) {
+        return fundingRepository.findById(id)
+                .orElseThrow(() -> new FundingException(FUNDING_NOT_FOUND));
+    }
+
+    @Transactional
+    public CreateFunding.Response createFunding(CreateFunding.Request request,
+            String memberKey) {
+        Member member = authenticationService.getMemberOrThrow(memberKey);
+        Reward reward = rewardService.getRewardOrThrow(request.rewardId());
+        validateReward(request, reward);
+        reward.decreaseStockQuantity(); // todo lock을 어디서 걸어야 할까 이 메소드 자체?
+
+        // 배송지 저장
+        AddressDto requestAddress = request.address();
+        if (requestAddress != null) {
+            member.addAddress(requestAddress.toEntity());
+        }
+
+        Funding funding = request.toEntity(reward.getPrice());
+        funding.addMember(member);
+        funding.addReward(reward);
+        funding.addDelivery(new Delivery(WAITING));
+        fundingRepository.save(funding);
+
+        return CreateFunding.Response.from(
+                reward.getTitle(), reward.getPrice(), funding.getId());
+    }
+
+    private static void validateReward(Request request, Reward reward) {
+        if (!Objects.equals(request.fundingProductId(), reward.getFundingProduct().getId())) {
+            throw new FundingException(REWARD_NOT_MATCH);
+        }
+
+        if (reward.getStockQuantity() < 1) {
+            throw new FundingException(OUT_OF_STOCK);
+        }
     }
 }

--- a/src/main/java/com/zerobase/funding/api/fundingproduct/service/FundingProductService.java
+++ b/src/main/java/com/zerobase/funding/api/fundingproduct/service/FundingProductService.java
@@ -113,7 +113,7 @@ public class FundingProductService {
         FundingProduct fundingProduct = fundingProductRepository.findByIdAndDeleted(id, false)
                 .orElseThrow(() -> new FundingProductException(FUNDING_PRODUCT_NOT_FOUND));
 
-        List<Funding> fundingList = fundingService.findByRewards(fundingProduct.getRewards());
+        List<Funding> fundingList = fundingService.getFundingByRewards(fundingProduct.getRewards());
 
         Integer views = viewsService.saveOrUpdate(String.valueOf(id), fundingProduct.getViews());
 

--- a/src/main/java/com/zerobase/funding/api/lock/annotation/DistributedLock.java
+++ b/src/main/java/com/zerobase/funding/api/lock/annotation/DistributedLock.java
@@ -1,0 +1,20 @@
+package com.zerobase.funding.api.lock.annotation;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Target({ METHOD, TYPE })
+@Retention(RUNTIME)
+public @interface DistributedLock {
+    String keyPrefix();
+
+    String idField();
+
+    long waitTime() default 5L;
+
+    long leasTime() default 3L;
+}

--- a/src/main/java/com/zerobase/funding/api/lock/aop/DistributedLockAspect.java
+++ b/src/main/java/com/zerobase/funding/api/lock/aop/DistributedLockAspect.java
@@ -1,0 +1,45 @@
+package com.zerobase.funding.api.lock.aop;
+
+import com.zerobase.funding.api.lock.annotation.DistributedLock;
+import com.zerobase.funding.api.lock.service.RedissonLockService;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+@Aspect
+public class DistributedLockAspect {
+
+    private final RedissonLockService redissonLockService;
+
+    @Around("@annotation(com.zerobase.funding.api.lock.annotation.DistributedLock)")
+    public Object lock(ProceedingJoinPoint joinPoint) throws Throwable {
+        Method method = ((MethodSignature) joinPoint.getSignature()).getMethod();
+        DistributedLock annotation = method.getAnnotation(DistributedLock.class);
+
+        String key = getLockKey(joinPoint, annotation);
+        redissonLockService.lock(key, annotation.waitTime(), annotation.leasTime());
+
+        try {
+            return joinPoint.proceed();
+        } finally {
+            redissonLockService.unlock(key);
+        }
+    }
+
+    private static String getLockKey(ProceedingJoinPoint joinPoint, DistributedLock annotation)
+            throws NoSuchFieldException, IllegalAccessException {
+        Object obj = joinPoint.getArgs()[0];
+        Field field = obj.getClass().getDeclaredField(annotation.idField());
+        field.trySetAccessible();
+        String value = field.get(obj).toString();
+
+        return annotation.keyPrefix() + value;
+    }
+}

--- a/src/main/java/com/zerobase/funding/api/lock/aop/LockCallNewTransaction.java
+++ b/src/main/java/com/zerobase/funding/api/lock/aop/LockCallNewTransaction.java
@@ -1,0 +1,15 @@
+package com.zerobase.funding.api.lock.aop;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class LockCallNewTransaction {
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Object proceed(final ProceedingJoinPoint joinPoint) throws Throwable {
+        return joinPoint.proceed();
+    }
+}

--- a/src/main/java/com/zerobase/funding/api/lock/exception/LockException.java
+++ b/src/main/java/com/zerobase/funding/api/lock/exception/LockException.java
@@ -1,0 +1,15 @@
+package com.zerobase.funding.api.lock.exception;
+
+import com.zerobase.funding.api.exception.CustomException;
+import com.zerobase.funding.api.exception.ErrorCode;
+
+public class LockException extends CustomException {
+
+    public LockException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public LockException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/src/main/java/com/zerobase/funding/api/lock/service/RedissonLockService.java
+++ b/src/main/java/com/zerobase/funding/api/lock/service/RedissonLockService.java
@@ -1,0 +1,40 @@
+package com.zerobase.funding.api.lock.service;
+
+import static com.zerobase.funding.api.exception.ErrorCode.INTERNAL_ERROR;
+import static com.zerobase.funding.api.exception.ErrorCode.RESOURCE_LOCKED;
+
+import com.zerobase.funding.api.lock.exception.LockException;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class RedissonLockService {
+
+    private final RedissonClient redissonClient;
+
+    public void lock(String key, Long waitTime, Long leaseTime) {
+        RLock lock = redissonClient.getLock(key);
+        log.info("{} try lock...", key);
+
+        try {
+            boolean tryLock = lock.tryLock(waitTime, leaseTime, TimeUnit.SECONDS);
+            if (!tryLock) {
+                log.error("lock acquisition failed.");
+                throw new LockException(RESOURCE_LOCKED);
+            }
+        } catch (InterruptedException e) {
+            throw new LockException(INTERNAL_ERROR, "lock thread is interrupted.");
+        }
+    }
+
+    public void unlock(String key) {
+        redissonClient.getLock(key).unlock();
+        log.info("unlock {}", key);
+    }
+}

--- a/src/main/java/com/zerobase/funding/api/member/dto/model/AddressDto.java
+++ b/src/main/java/com/zerobase/funding/api/member/dto/model/AddressDto.java
@@ -1,12 +1,18 @@
 package com.zerobase.funding.api.member.dto.model;
 
 import com.zerobase.funding.domain.member.entity.Address;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 
 @Builder
 public record AddressDto(
+        @NotBlank
         String roadAddress,
+
+        @NotBlank
         String addressDetail,
+
+        @NotBlank
         String zipcode
 ) {
 

--- a/src/main/java/com/zerobase/funding/api/paymenthistory/controller/PaymentHistoryController.java
+++ b/src/main/java/com/zerobase/funding/api/paymenthistory/controller/PaymentHistoryController.java
@@ -1,0 +1,34 @@
+package com.zerobase.funding.api.paymenthistory.controller;
+
+import com.zerobase.funding.api.paymenthistory.dto.ApprovalResult;
+import com.zerobase.funding.api.paymenthistory.service.PaymentHistoryService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/payment-history")
+@RequiredArgsConstructor
+@RestController
+public class PaymentHistoryController {
+
+    private final PaymentHistoryService paymentHistoryService;
+
+    /**
+     * 임의 결제 승인 요청 결과 저장 api <br>
+     * 결제 관련 api를 제공하지 않기 때문에
+     * 결제 흐름에서 마지막 단계인 승인 요청 결과에 대해 저장하는 부분만 임의로 작성하였습니다.
+     * @param request 결제 승인 요청 결과
+     * @return void
+     */
+    @Deprecated
+    @PostMapping
+    public ResponseEntity<Void> paymentApprovalResult(
+            @RequestBody @Valid ApprovalResult request) {
+        paymentHistoryService.paymentApprovalResult(request);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/zerobase/funding/api/paymenthistory/dto/ApprovalResult.java
+++ b/src/main/java/com/zerobase/funding/api/paymenthistory/dto/ApprovalResult.java
@@ -1,0 +1,13 @@
+package com.zerobase.funding.api.paymenthistory.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ApprovalResult(
+        @NotNull
+        Long fundingId,
+
+        @NotNull
+        Integer amount
+) {
+
+}

--- a/src/main/java/com/zerobase/funding/api/paymenthistory/exception/PaymentHistoryException.java
+++ b/src/main/java/com/zerobase/funding/api/paymenthistory/exception/PaymentHistoryException.java
@@ -1,0 +1,11 @@
+package com.zerobase.funding.api.paymenthistory.exception;
+
+import com.zerobase.funding.api.exception.CustomException;
+import com.zerobase.funding.api.exception.ErrorCode;
+
+public class PaymentHistoryException extends CustomException {
+
+    public PaymentHistoryException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/zerobase/funding/api/paymenthistory/service/PaymentHistoryService.java
+++ b/src/main/java/com/zerobase/funding/api/paymenthistory/service/PaymentHistoryService.java
@@ -1,0 +1,36 @@
+package com.zerobase.funding.api.paymenthistory.service;
+
+import static com.zerobase.funding.api.exception.ErrorCode.INVALID_PAYMENT;
+
+import com.zerobase.funding.api.funding.service.FundingService;
+import com.zerobase.funding.api.paymenthistory.dto.ApprovalResult;
+import com.zerobase.funding.api.paymenthistory.exception.PaymentHistoryException;
+import com.zerobase.funding.domain.funding.entity.Funding;
+import com.zerobase.funding.domain.paymenthistory.entity.PaymentHistory;
+import com.zerobase.funding.domain.paymenthistory.repository.PaymentHistoryRepository;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class PaymentHistoryService {
+
+    private final PaymentHistoryRepository paymentHistoryRepository;
+    private final FundingService fundingService;
+
+    @Transactional
+    public void paymentApprovalResult(ApprovalResult request) {
+        Funding funding = fundingService.getFundingById(request.fundingId());
+        validatePayment(request, funding);
+
+        paymentHistoryRepository.save(PaymentHistory.of(request.amount(), funding));
+    }
+
+    private static void validatePayment(ApprovalResult request, Funding funding) {
+        if (!Objects.equals(funding.getFundingPrice(), request.amount())) {
+            throw new PaymentHistoryException(INVALID_PAYMENT);
+        }
+    }
+}

--- a/src/main/java/com/zerobase/funding/api/reward/exception/RewardException.java
+++ b/src/main/java/com/zerobase/funding/api/reward/exception/RewardException.java
@@ -1,0 +1,11 @@
+package com.zerobase.funding.api.reward.exception;
+
+import com.zerobase.funding.api.exception.CustomException;
+import com.zerobase.funding.api.exception.ErrorCode;
+
+public class RewardException extends CustomException {
+
+    public RewardException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/zerobase/funding/api/reward/service/RewardService.java
+++ b/src/main/java/com/zerobase/funding/api/reward/service/RewardService.java
@@ -1,0 +1,23 @@
+package com.zerobase.funding.api.reward.service;
+
+import static com.zerobase.funding.api.exception.ErrorCode.REWARD_NOT_FOUND;
+
+import com.zerobase.funding.api.reward.exception.RewardException;
+import com.zerobase.funding.domain.reward.entity.Reward;
+import com.zerobase.funding.domain.reward.repository.RewardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class RewardService {
+
+    private final RewardRepository rewardRepository;
+
+    public Reward getRewardOrThrow(Long id) {
+        return rewardRepository.findByIdFetch(id)
+                .orElseThrow(() -> new RewardException(REWARD_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/zerobase/funding/domain/delivery/entity/Status.java
+++ b/src/main/java/com/zerobase/funding/domain/delivery/entity/Status.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum Status {
+    WAITING("배송대기"),
     SHIPPING("배송중"),
     COMPLETE("배송완료"),
     CANCEL("배송취소");

--- a/src/main/java/com/zerobase/funding/domain/funding/entity/Funding.java
+++ b/src/main/java/com/zerobase/funding/domain/funding/entity/Funding.java
@@ -4,6 +4,7 @@ import com.zerobase.funding.domain.common.entity.BaseTimeEntity;
 import com.zerobase.funding.domain.delivery.entity.Delivery;
 import com.zerobase.funding.domain.member.entity.Member;
 import com.zerobase.funding.domain.reward.entity.Reward;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -40,7 +41,7 @@ public class Funding extends BaseTimeEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     @JoinColumn(name = "delivery_id")
     private Delivery delivery;
 
@@ -52,5 +53,17 @@ public class Funding extends BaseTimeEntity {
     public Funding(Status status, Integer fundingPrice) {
         this.status = status;
         this.fundingPrice = fundingPrice;
+    }
+
+    public void addMember(Member member) {
+        this.member = member;
+    }
+
+    public void addReward(Reward reward) {
+        this.reward = reward;
+    }
+
+    public void addDelivery(Delivery delivery) {
+        this.delivery = delivery;
     }
 }

--- a/src/main/java/com/zerobase/funding/domain/funding/entity/Funding.java
+++ b/src/main/java/com/zerobase/funding/domain/funding/entity/Funding.java
@@ -16,6 +16,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,6 +26,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@Table(uniqueConstraints = @UniqueConstraint(name = "uk_member_id_reward_id",
+        columnNames = {"member_id", "reward_id"}))
 public class Funding extends BaseTimeEntity {
 
     @Id
@@ -45,7 +49,7 @@ public class Funding extends BaseTimeEntity {
     @JoinColumn(name = "delivery_id")
     private Delivery delivery;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "reward_id")
     private Reward reward;
 

--- a/src/main/java/com/zerobase/funding/domain/funding/repository/FundingRepository.java
+++ b/src/main/java/com/zerobase/funding/domain/funding/repository/FundingRepository.java
@@ -2,6 +2,7 @@ package com.zerobase.funding.domain.funding.repository;
 
 import com.zerobase.funding.domain.funding.entity.Funding;
 import com.zerobase.funding.domain.funding.entity.Status;
+import com.zerobase.funding.domain.member.entity.Member;
 import com.zerobase.funding.domain.reward.entity.Reward;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,4 +10,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface FundingRepository extends JpaRepository<Funding, Long> {
 
     List<Funding> findByRewardInAndStatus(List<Reward> rewards, Status status);
+
+    boolean existsByMemberAndReward(Member member, Reward reward);
 }

--- a/src/main/java/com/zerobase/funding/domain/fundingproduct/entity/FundingProduct.java
+++ b/src/main/java/com/zerobase/funding/domain/fundingproduct/entity/FundingProduct.java
@@ -67,12 +67,13 @@ public class FundingProduct extends BaseTimeEntity {
 
     @Builder
     public FundingProduct(String title, String description, LocalDate startDate, LocalDate endDate,
-            Integer targetAmount) {
+            Integer targetAmount, Long id) {
         this.title = title;
         this.description = description;
         this.startDate = startDate;
         this.endDate = endDate;
         this.targetAmount = targetAmount;
+        this.id = id;
     }
 
     public void addMember(Member member) {

--- a/src/main/java/com/zerobase/funding/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/zerobase/funding/domain/member/repository/MemberRepository.java
@@ -9,4 +9,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
 
     Optional<Member> findByMemberKey(String memberKey);
+
+    boolean existsByMemberKey(String memberKey);
 }

--- a/src/main/java/com/zerobase/funding/domain/paymenthistory/entity/PaymentHistory.java
+++ b/src/main/java/com/zerobase/funding/domain/paymenthistory/entity/PaymentHistory.java
@@ -10,6 +10,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -32,10 +33,21 @@ public class PaymentHistory extends BaseTimeEntity {
     private Integer paymentPrice;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "funding_id")
     private Funding funding;
 
     public PaymentHistory(Status status, Integer paymentPrice) {
         this.status = status;
         this.paymentPrice = paymentPrice;
+    }
+
+    public void addFunding(Funding funding) {
+        this.funding = funding;
+    }
+
+    public static PaymentHistory of(Integer paymentPrice, Funding funding) {
+        PaymentHistory paymentHistory = new PaymentHistory(Status.COMPLETE, paymentPrice);
+        paymentHistory.addFunding(funding);
+        return paymentHistory;
     }
 }

--- a/src/main/java/com/zerobase/funding/domain/reward/entity/Reward.java
+++ b/src/main/java/com/zerobase/funding/domain/reward/entity/Reward.java
@@ -51,4 +51,8 @@ public class Reward extends BaseTimeEntity {
     public void setFundingProduct(FundingProduct fundingProduct) {
         this.fundingProduct = fundingProduct;
     }
+
+    public void decreaseStockQuantity() {
+        stockQuantity--;
+    }
 }

--- a/src/main/java/com/zerobase/funding/domain/reward/repository/CustomRewardRepository.java
+++ b/src/main/java/com/zerobase/funding/domain/reward/repository/CustomRewardRepository.java
@@ -1,0 +1,9 @@
+package com.zerobase.funding.domain.reward.repository;
+
+import com.zerobase.funding.domain.reward.entity.Reward;
+import java.util.Optional;
+
+public interface CustomRewardRepository {
+
+    Optional<Reward> findByIdFetch(Long id);
+}

--- a/src/main/java/com/zerobase/funding/domain/reward/repository/RewardRepository.java
+++ b/src/main/java/com/zerobase/funding/domain/reward/repository/RewardRepository.java
@@ -3,5 +3,5 @@ package com.zerobase.funding.domain.reward.repository;
 import com.zerobase.funding.domain.reward.entity.Reward;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface RewardRepository extends JpaRepository<Reward, Long> {
+public interface RewardRepository extends JpaRepository<Reward, Long>, CustomRewardRepository {
 }

--- a/src/main/java/com/zerobase/funding/domain/reward/repository/impl/CustomRewardRepositoryImpl.java
+++ b/src/main/java/com/zerobase/funding/domain/reward/repository/impl/CustomRewardRepositoryImpl.java
@@ -1,0 +1,25 @@
+package com.zerobase.funding.domain.reward.repository.impl;
+
+import static com.zerobase.funding.domain.fundingproduct.entity.QFundingProduct.fundingProduct;
+import static com.zerobase.funding.domain.reward.entity.QReward.reward;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.zerobase.funding.domain.reward.entity.Reward;
+import com.zerobase.funding.domain.reward.repository.CustomRewardRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CustomRewardRepositoryImpl implements CustomRewardRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<Reward> findByIdFetch(Long id) {
+        return Optional.ofNullable(queryFactory
+                .selectFrom(reward)
+                .join(reward.fundingProduct, fundingProduct).fetchJoin()
+                .where(reward.id.eq(id))
+                .fetchOne());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,8 +38,10 @@ scheduler:
   funding-product:
     views: "0 0 0 * * *"
 
-logging:
-  level:
-    org:
-      springframework:
-        security: DEBUG
+#logging:
+#  level:
+#    org:
+#      springframework:
+#        security: DEBUG
+#        transaction:
+#          interceptor: TRACE

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,8 @@ spring:
     url: jdbc:mysql://localhost:3306/funding?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
     username: root
     password: mysql
+    hikari:
+      maximum-pool-size: 20
 
   jpa:
     database: mysql
@@ -38,10 +40,12 @@ scheduler:
   funding-product:
     views: "0 0 0 * * *"
 
-#logging:
-#  level:
-#    org:
-#      springframework:
-#        security: DEBUG
-#        transaction:
-#          interceptor: TRACE
+logging:
+  level:
+    org:
+      springframework:
+#        security: debug
+        transaction:
+          interceptor: debug
+    com.zaxxer.hikari: trace
+    com.zaxxer.hikari.HikariConfig: debug

--- a/src/test/java/com/zerobase/funding/api/funding/service/FundingServiceLockTest.java
+++ b/src/test/java/com/zerobase/funding/api/funding/service/FundingServiceLockTest.java
@@ -1,0 +1,107 @@
+package com.zerobase.funding.api.funding.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.zerobase.funding.api.funding.dto.CreateFunding.Request;
+import com.zerobase.funding.domain.fundingproduct.entity.FundingProduct;
+import com.zerobase.funding.domain.fundingproduct.repository.FundingProductRepository;
+import com.zerobase.funding.domain.member.entity.Address;
+import com.zerobase.funding.domain.member.entity.Member;
+import com.zerobase.funding.domain.member.entity.Role;
+import com.zerobase.funding.domain.member.repository.MemberRepository;
+import com.zerobase.funding.domain.reward.entity.Reward;
+import com.zerobase.funding.domain.reward.repository.RewardRepository;
+import java.time.LocalDate;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class FundingServiceLockTest {
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    RewardRepository rewardRepository;
+
+    @Autowired
+    FundingProductRepository fundingProductRepository;
+
+    @Autowired
+    FundingService fundingService;
+
+    int threadCount = 100;
+
+    @BeforeEach
+    void setup() {
+        FundingProduct fundingProduct = fundingProductRepository.save(
+                FundingProduct.builder()
+                        .title("제품")
+                        .description("설명")
+                        .startDate(LocalDate.now())
+                        .endDate(LocalDate.now())
+                        .targetAmount(10000)
+                        .build());
+
+        Reward reward = Reward.builder()
+                .title("title")
+                .description("desc")
+                .price(10000)
+                .stockQuantity(100)
+                .build();
+
+        reward.setFundingProduct(fundingProduct);
+        rewardRepository.save(reward);
+
+        for (int i = 0; i < threadCount; i++) {
+            Member member = Member.builder()
+                    .name("aa")
+                    .email(i + "test@gmail.com")
+                    .profile("bbb")
+                    .role(Role.USER)
+                    .memberKey(String.valueOf(i))
+                    .build();
+
+            member.addAddress(Address.builder()
+                    .roadAddress("road")
+                    .addressDetail("detail")
+                    .zipcode("1234-56")
+                    .build());
+
+            memberRepository.save(member);
+        }
+    }
+
+    @Test
+    @DisplayName("리워드 수량 감소 동시성 제어")
+    void createFunding_concurrency_control() throws InterruptedException {
+        // given
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch countDownLatch = new CountDownLatch(threadCount);
+        Request request = new Request(1L, 1L, null);
+
+        // when
+        IntStream.range(0, threadCount).forEach(o -> executorService.execute(() -> {
+            try {
+                fundingService.createFunding(request, String.valueOf(o));
+            } finally {
+                countDownLatch.countDown();
+            }
+        }));
+
+        countDownLatch.await();
+
+        // then
+        Reward reward = rewardRepository.findById(1L).get();
+        assertEquals(100 - threadCount, reward.getStockQuantity());
+    }
+}

--- a/src/test/java/com/zerobase/funding/api/funding/service/FundingServiceLockTest.java
+++ b/src/test/java/com/zerobase/funding/api/funding/service/FundingServiceLockTest.java
@@ -39,7 +39,9 @@ public class FundingServiceLockTest {
     @Autowired
     FundingService fundingService;
 
-    int threadCount = 100;
+    // 현재 hikariCP에서 허용가능한 범위로 설정 (pool size를 20으로 설정해둬서 20개부터는 테스트 실패,
+    // thransaction이 한번 더 여리는 이유로 pool size에 따라 실패 여부가 갈림)
+    int threadCount = 19;
 
     @BeforeEach
     void setup() {

--- a/src/test/java/com/zerobase/funding/api/funding/service/FundingServiceTest.java
+++ b/src/test/java/com/zerobase/funding/api/funding/service/FundingServiceTest.java
@@ -1,0 +1,175 @@
+package com.zerobase.funding.api.funding.service;
+
+import static com.zerobase.funding.api.exception.ErrorCode.ADDRESS_IS_REQUIRED;
+import static com.zerobase.funding.api.exception.ErrorCode.OUT_OF_STOCK;
+import static com.zerobase.funding.api.exception.ErrorCode.REWARD_NOT_MATCH;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.zerobase.funding.api.auth.service.AuthenticationService;
+import com.zerobase.funding.api.funding.dto.CreateFunding.Request;
+import com.zerobase.funding.api.funding.dto.CreateFunding.Response;
+import com.zerobase.funding.api.funding.exception.FundingException;
+import com.zerobase.funding.api.member.dto.model.AddressDto;
+import com.zerobase.funding.api.reward.service.RewardService;
+import com.zerobase.funding.domain.funding.entity.Funding;
+import com.zerobase.funding.domain.funding.entity.Status;
+import com.zerobase.funding.domain.funding.repository.FundingRepository;
+import com.zerobase.funding.domain.fundingproduct.entity.FundingProduct;
+import com.zerobase.funding.domain.member.entity.Member;
+import com.zerobase.funding.domain.reward.entity.Reward;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FundingServiceTest {
+
+    @Mock
+    FundingRepository fundingRepository;
+
+    @Mock
+    AuthenticationService authenticationService;
+
+    @Mock
+    RewardService rewardService;
+
+    @InjectMocks
+    FundingService fundingService;
+
+    @Nested
+    @DisplayName("펀딩하기 메소드")
+    class CreateFundingMethod {
+
+        String rewardTitle = "title";
+        Integer price = 10000;
+        String memberKey = "key";
+
+        Member member = Member.builder()
+                .memberKey(memberKey)
+                .build();
+        Reward reward = Reward.builder()
+                .title(rewardTitle)
+                .price(price)
+                .stockQuantity(1)
+                .build();
+        Funding funding = Funding.builder()
+                .fundingPrice(price)
+                .status(Status.IN_PROGRESS)
+                .build();
+
+        @Test
+        @DisplayName("성공")
+        void createFunding_success() {
+            // given
+            reward.setFundingProduct(FundingProduct.builder()
+                    .id(1L)
+                    .build());
+
+            given(authenticationService.getMemberOrThrow(any()))
+                    .willReturn(member);
+
+            given(rewardService.getRewardOrThrow(any()))
+                    .willReturn(reward);
+
+            given(fundingRepository.save(any()))
+                    .willReturn(funding);
+
+            // when
+            Request request = new Request(1L, 1L,
+                    AddressDto.builder()
+                            .roadAddress("road")
+                            .addressDetail("detail")
+                            .zipcode("1234-56")
+                            .build());
+
+            Response response =
+                    fundingService.createFunding(request, memberKey);
+
+            // then
+            assertEquals(price, response.price());
+            assertEquals(rewardTitle, response.rewardTitle());
+        }
+
+        @Test
+        @DisplayName("실패 - 상품과 리워드가 연관되어야 한다.")
+        void createFunding_reward_not_match() {
+            // given
+            reward.setFundingProduct(FundingProduct.builder()
+                    .id(2L)
+                    .build());
+
+            given(authenticationService.getMemberOrThrow(any()))
+                    .willReturn(member);
+
+            given(rewardService.getRewardOrThrow(any()))
+                    .willReturn(reward);
+
+            // when
+            // then
+            Request request = new Request(1L, 1L, null);
+            assertThatThrownBy(() ->
+                    fundingService.createFunding(request, memberKey))
+                    .isInstanceOf(FundingException.class)
+                    .hasMessageContaining(REWARD_NOT_MATCH.getMessage());
+        }
+
+        @Test
+        @DisplayName("실패 - 리워드의 재고가 하나 이상 있어야 한다.")
+        void createFunding_out_of_stock() {
+            // given
+            Reward reward = Reward.builder()
+                    .title(rewardTitle)
+                    .price(price)
+                    .stockQuantity(0)
+                    .build();
+
+            reward.setFundingProduct(FundingProduct.builder()
+                    .id(1L)
+                    .build());
+
+            given(authenticationService.getMemberOrThrow(any()))
+                    .willReturn(member);
+
+            given(rewardService.getRewardOrThrow(any()))
+                    .willReturn(reward);
+
+            // when
+            // then
+            Request request = new Request(1L, 1L, null);
+            assertThatThrownBy(() ->
+                    fundingService.createFunding(request, memberKey))
+                    .isInstanceOf(FundingException.class)
+                    .hasMessageContaining(OUT_OF_STOCK.getMessage());
+        }
+
+        @Test
+        @DisplayName("실패 - 주소는 필수 값이다.")
+        void createFunding_address_is_required() {
+            // given
+            reward.setFundingProduct(FundingProduct.builder()
+                    .id(1L)
+                    .build());
+
+            given(authenticationService.getMemberOrThrow(any()))
+                    .willReturn(member);
+
+            given(rewardService.getRewardOrThrow(any()))
+                    .willReturn(reward);
+
+            // when
+            // then
+            Request request = new Request(1L, 1L, null);
+            assertThatThrownBy(() ->
+                    fundingService.createFunding(request, memberKey))
+                    .isInstanceOf(FundingException.class)
+                    .hasMessageContaining(ADDRESS_IS_REQUIRED.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/zerobase/funding/api/funding/service/FundingServiceTest.java
+++ b/src/test/java/com/zerobase/funding/api/funding/service/FundingServiceTest.java
@@ -95,6 +95,7 @@ class FundingServiceTest {
             // then
             assertEquals(price, response.price());
             assertEquals(rewardTitle, response.rewardTitle());
+            assertEquals(reward.getStockQuantity(), 0);
         }
 
         @Test

--- a/src/test/java/com/zerobase/funding/api/fundingproduct/service/FundingProductServiceTest.java
+++ b/src/test/java/com/zerobase/funding/api/fundingproduct/service/FundingProductServiceTest.java
@@ -248,7 +248,7 @@ class FundingProductServiceTest {
         given(fundingProductRepository.findByIdAndDeleted(any(), anyBoolean()))
                 .willReturn(Optional.of(fundingProduct));
 
-        given(fundingService.findByRewards(any()))
+        given(fundingService.getFundingByRewards(any()))
                 .willReturn(List.of(Funding.builder().fundingPrice(70000).build(),
                         Funding.builder().fundingPrice(5800).build()));
 

--- a/src/test/java/com/zerobase/funding/http/funding.http
+++ b/src/test/java/com/zerobase/funding/http/funding.http
@@ -5,7 +5,7 @@ Authorization: {{token}}
 
 {
   "fundingProductId": 1,
-  "rewardId": 1,
+  "rewardId": 2,
   "address": {
     "roadAddress": "부산시 대연동",
     "addressDetail": "어쩌구 저쩌구",

--- a/src/test/java/com/zerobase/funding/http/funding.http
+++ b/src/test/java/com/zerobase/funding/http/funding.http
@@ -1,0 +1,14 @@
+### create funding
+POST {{host}}/funding
+Content-Type: application/json
+Authorization: {{token}}
+
+{
+  "fundingProductId": 1,
+  "rewardId": 1,
+  "address": {
+    "roadAddress": "부산시 대연동",
+    "addressDetail": "어쩌구 저쩌구",
+    "zipcode": "123-1"
+  }
+}

--- a/src/test/java/com/zerobase/funding/http/payment-history.http
+++ b/src/test/java/com/zerobase/funding/http/payment-history.http
@@ -1,0 +1,9 @@
+### approval result
+POST {{host}}/payment-history
+Content-Type: application/json
+Authorization: {{token}}
+
+{
+  "fundingId": 1,
+  "amount": 35000
+}


### PR DESCRIPTION
### 변경사항
**AS-IS**

**TO-BE**
펀딩하기 api 작성 및 리워드 재고 수량에 대한 동시성 제어 기능을 추가하였습니다.
참고) 펀딩하기는 기능 흐름에 따라 작성해보았고, 결제 관련 api는 별도 제공하지 않아서 제외하였습니다. 결제 내역에 대한 정보를 저장하기 위해 결제 중 마지막 단계인 승인 요청 응답 결과를 받는 api를 임의로 작성하였습니다.

프로젝트 내 펀딩하기 결제 flow
- (클라이언트) 펀딩하기 클릭 → 펀딩하기 api 호출 → 요청 검증 및 펀딩 생성 → 응답(가격, 펀딩 id, 리워드 이름)
- 위 정보를 바탕으로 결제하기 클릭 → 결제 요청 api 호출 → 검증 및 결제 정보 저장 → 응답
- (클라) PG사에 결제창 호출 → 사용자가 결제 진행 → PG사에 결제 요청 → PG사에서 요청 검증 후 성공/실패 URL로 리다이렉트(서버 api) → 성공 시 PG사에 승인 요청(실패 시 클라이언트로 실패 응답) → 승인 요청 응답 결과 저장 → 클라이언트로 결과 응답

재고 수량 동시성 제어
- Redisson을 이용한 분산 락 적용
- 활용 편의를 위해 aop로 처리

**트러블슈팅**
- lock을 해제하기 전에 트랜잭션 커밋이 일어나야 다음 lock을 획득한 스레드에서 올바른 값을 조회할 수 있다. (정합성)
- 방법 1) 펀딩하기 메소드를 새로운 트랜잭션으로 열리도록 설정값을 추가(requires_new) -> 이미 aop 프록시로 가져온 상태라서 하나의 트랜잭션으로 묶여 설정 값이 적용되지 않음(그런 것으로 판단함)
- 방법 2) joinPoint.proceed를 수행할 객체를 새로 만들어 새로운 트랜잭션으로 수행 -> 문제 없이 잘 동작하지만 multi thread로 테스트 해봤을 때 속도가 느려서 대부분의 스레드가 주어진 시간안에 lock을 획득하지 못하여 실패함
- 방법 3) transaction을 새로 여는것에만 꽂혔었는데, save하는 즉시 밀어주면 된다. saveAndFlush()로 해결

### 테스트
- [x] 테스트 코드
- [x] API 테스트 
